### PR TITLE
Cleaned up the test section.

### DIFF
--- a/recipes/holoplot/meta.yaml
+++ b/recipes/holoplot/meta.yaml
@@ -29,18 +29,11 @@ requirements:
 test:
   imports:
     - holoplot
-    - holoplot.examples
-    - holoplot.examples.assets
-    - holoplot.examples.user_guide
-    - holoplot.examples.user_guide.images
-    - holoplot.tests
   requires:
-    - coveralls
-    - flake8
-    - nbsmoke >=0.2.0
     - nose
     - parameterized
-    - pytest
+  commands:
+    - nosetests holoplot
 
 about:
   home: https://pyviz.github.io/holoplot/


### PR DESCRIPTION
In the future, holoplot might provide a command to install the examples, but it doesn't currently. So only the unit tests currently make sense for the holoplot package here.

(Meanwhile, I think the hope is for holoplot not to be released on conda-forge until 0.1, which should be really soon...)
